### PR TITLE
delete fmt dependence

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -3,7 +3,6 @@ package jsonparser
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"math"
 	"strconv"
 )
@@ -1006,6 +1005,7 @@ func ArrayEach(data []byte, cb func(value []byte, dataType ValueType, offset int
 
 // ObjectEach iterates over the key-value pairs of a JSON object, invoking a given callback for each such entry
 func ObjectEach(data []byte, callback func(key []byte, value []byte, dataType ValueType, offset int) error, keys ...string) (err error) {
+
 	offset := 0
 
 	// Descend to the desired key, if requested
@@ -1076,6 +1076,7 @@ func ObjectEach(data []byte, callback func(key []byte, value []byte, dataType Va
 			offset++
 		}
 
+
 		// Step 3: find the associated value, then invoke the callback
 		if value, valueType, off, err := Get(data[offset:]); err != nil {
 			return err
@@ -1132,7 +1133,7 @@ func GetString(data []byte, keys ...string) (val string, err error) {
 	}
 
 	if t != String {
-		return "", fmt.Errorf("Value is not a string: %s", string(v))
+		return "", errors.New("Value is not a string")
 	}
 
 	// If no escapes return raw conten
@@ -1154,7 +1155,7 @@ func GetFloat(data []byte, keys ...string) (val float64, err error) {
 	}
 
 	if t != Number {
-		return 0, fmt.Errorf("Value is not a number: %s", string(v))
+		return 0, errors.New("Value is not a number")
 	}
 
 	return ParseFloat(v)
@@ -1170,7 +1171,7 @@ func GetInt(data []byte, keys ...string) (val int64, err error) {
 	}
 
 	if t != Number {
-		return 0, fmt.Errorf("Value is not a number: %s", string(v))
+		return 0, errors.New("Value is not a number")
 	}
 
 	return ParseInt(v)
@@ -1187,7 +1188,7 @@ func GetBoolean(data []byte, keys ...string) (val bool, err error) {
 	}
 
 	if t != Boolean {
-		return false, fmt.Errorf("Value is not a boolean: %s", string(v))
+		return false, errors.New("Value is not a boolean")
 	}
 
 	return ParseBoolean(v)

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,7 +3,6 @@ package jsonparser
 import (
 	"bytes"
 	"fmt"
-	_ "fmt"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
**Description**: This  PR is used to delete all fmt lib dependence in jsonparser, because of tinyGo will auto link fmt interface into bin when we compiling it via `--wasm`, so we need a clean it up

